### PR TITLE
feat: Add Multi-Auth Gradle plugin with OAuth provider configuration …

### DIFF
--- a/buildSrc/src/main/kotlin/GenerateOAuthConfigTask.kt
+++ b/buildSrc/src/main/kotlin/GenerateOAuthConfigTask.kt
@@ -53,7 +53,7 @@ open class GenerateOAuthConfigTask : DefaultTask() {
         logger.info("Configured providers: ${providers.keys.joinToString(", ")}")
     }
     
-    private fun generateJson(value: Any, indent: String = ""): String {
+    private fun generateJson(value: Any?, indent: String = ""): String {
         return when (value) {
             is Map<*, *> -> {
                 val entries = value.entries.joinToString(",\n") { (k, v) ->
@@ -144,7 +144,7 @@ open class GenerateKotlinOAuthConfigTask : DefaultTask() {
         logger.info("Generated Kotlin OAuth configuration: ${outputFile.get().asFile.absolutePath}")
     }
     
-    private fun generateJson(value: Any, indent: String = ""): String {
+    private fun generateJson(value: Any?, indent: String = ""): String {
         return when (value) {
             is Map<*, *> -> {
                 val entries = value.entries.joinToString(",\n") { (k, v) ->

--- a/buildSrc/src/main/kotlin/MultiAuthPlugin.kt
+++ b/buildSrc/src/main/kotlin/MultiAuthPlugin.kt
@@ -88,26 +88,47 @@ class MultiAuthPlugin : Plugin<Project> {
         }
         
         // Make the generate task run before compilation
-        project.tasks.named("compileKotlin") {
-            dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig")
+        // Handle both regular Kotlin projects and Kotlin Multiplatform projects
+        project.tasks.findByName("compileKotlin")?.let { compileKotlinTask ->
+            compileKotlinTask.dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig")
+        }
+        
+        // For Kotlin Multiplatform projects, also run before common compilation
+        project.tasks.findByName("compileCommonMainKotlinMetadata")?.let { compileCommonTask ->
+            compileCommonTask.dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig")
         }
         
         // For Android projects, also run before Android compilation
         project.plugins.withId("com.android.application") {
-            project.tasks.named("compileDebugKotlin") {
-                dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
+            // Try to find Android compilation tasks (they may not exist in all configurations)
+            project.tasks.findByName("compileDebugKotlin")?.let { task ->
+                task.dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
             }
-            project.tasks.named("compileReleaseKotlin") {
-                dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
+            project.tasks.findByName("compileReleaseKotlin")?.let { task ->
+                task.dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
+            }
+            // For Kotlin Multiplatform Android targets
+            project.tasks.findByName("compileDebugKotlinAndroid")?.let { task ->
+                task.dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
+            }
+            project.tasks.findByName("compileReleaseKotlinAndroid")?.let { task ->
+                task.dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
             }
         }
         
         project.plugins.withId("com.android.library") {
-            project.tasks.named("compileDebugKotlin") {
-                dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
+            project.tasks.findByName("compileDebugKotlin")?.let { task ->
+                task.dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
             }
-            project.tasks.named("compileReleaseKotlin") {
-                dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
+            project.tasks.findByName("compileReleaseKotlin")?.let { task ->
+                task.dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
+            }
+            // For Kotlin Multiplatform Android targets
+            project.tasks.findByName("compileDebugKotlinAndroid")?.let { task ->
+                task.dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
+            }
+            project.tasks.findByName("compileReleaseKotlinAndroid")?.let { task ->
+                task.dependsOn("generateOAuthConfig", "generateKotlinOAuthConfig", "generateAndroidOAuthResources")
             }
         }
     }
@@ -233,4 +254,24 @@ open class OAuthProviderConfiguration {
     
     // Internal property for provider ID (set by extension methods)
     var providerId: String = ""
+    
+    /**
+     * Creates a copy of this configuration with the specified provider ID.
+     */
+    fun copy(providerId: String): OAuthProviderConfiguration {
+        return OAuthProviderConfiguration().apply {
+            this.clientId = this@OAuthProviderConfiguration.clientId
+            this.clientSecret = this@OAuthProviderConfiguration.clientSecret
+            this.redirectUri = this@OAuthProviderConfiguration.redirectUri
+            this.scopes = this@OAuthProviderConfiguration.scopes
+            this.customAuthUrl = this@OAuthProviderConfiguration.customAuthUrl
+            this.customTokenUrl = this@OAuthProviderConfiguration.customTokenUrl
+            this.customUserInfoUrl = this@OAuthProviderConfiguration.customUserInfoUrl
+            this.customRevokeUrl = this@OAuthProviderConfiguration.customRevokeUrl
+            this.usePKCE = this@OAuthProviderConfiguration.usePKCE
+            this.additionalParams = this@OAuthProviderConfiguration.additionalParams
+            this.isEnabled = this@OAuthProviderConfiguration.isEnabled
+            this.providerId = providerId
+        }
+    }
 }

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/multiauth.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/multiauth.properties
@@ -1,0 +1,1 @@
+implementation-class=MultiAuthPlugin


### PR DESCRIPTION
This pull request improves the Gradle OAuth configuration plugin by making it more robust and flexible for different Kotlin and Android project setups. The main changes include enhanced task dependency handling to support multiplatform and Android variants, a new utility method for copying provider configurations, and minor fixes to JSON generation.

**Task dependency improvements:**

* Updated `MultiAuthPlugin.kt` to use `findByName` and conditional logic for setting task dependencies, ensuring that configuration generation tasks run before compilation in regular, multiplatform, and Android projects, including their specific variants. This makes the plugin compatible with more project types and avoids errors when tasks are missing.

**Configuration utilities:**

* Added a `copy(providerId: String)` method to `OAuthProviderConfiguration`, allowing easy duplication of configuration objects with a new provider ID. This helps with managing multiple OAuth providers programmatically.

**Bug fixes and minor improvements:**

* Changed the `generateJson` function parameter type from `Any` to `Any?` in both `GenerateOAuthConfigTask` and `GenerateKotlinOAuthConfigTask`, preventing possible crashes when handling null values during JSON generation. [[1]](diffhunk://#diff-d950cc9c71000008a4503cdc9391f720771c78f2d1c2374b6878b32f6933a42aL56-R56) [[2]](diffhunk://#diff-d950cc9c71000008a4503cdc9391f720771c78f2d1c2374b6878b32f6933a42aL147-R147)
* Added the `implementation-class=MultiAuthPlugin` property to `multiauth.properties` to ensure Gradle recognizes and loads the plugin correctly